### PR TITLE
Add Terraform configuration for t3.micro EC2 instance in us-east-2 with SSH access

### DIFF
--- a/ec2-instance-us-east-2.tf
+++ b/ec2-instance-us-east-2.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_security_group" "ssh_access" {
+  name        = "ssh_access"
+  description = "Allow SSH access from anywhere"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Creator = "terraform-agent"
+  }
+}
+
+resource "aws_instance" "t3_micro_instance" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+  associate_public_ip_address = true
+  vpc_security_group_ids = [aws_security_group.ssh_access.id]
+  tags = {
+    Creator = "terraform-agent"
+  }
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}


### PR DESCRIPTION
This PR adds a new Terraform configuration file that provisions a t3.micro EC2 instance in the us-east-2 region. The instance has an attached public IP and a security group allowing SSH access from anywhere. All resources are tagged with Creator: terraform-agent.